### PR TITLE
Added status callback

### DIFF
--- a/mockup-server/mockupserver.py
+++ b/mockup-server/mockupserver.py
@@ -13,7 +13,7 @@ from wsgiref.simple_server import make_server
 from mako.lookup import TemplateLookup
 from sqlalchemy import Integer, Unicode
 from nanohttp import text, json, context, RestController, HTTPBadRequest, \
-    HTTPNotFound, settings, action
+    HTTPNotFound, settings, action, HTTPStatus
 from restfulpy.authorization import authorize
 from restfulpy.application import Application
 from restfulpy.authentication import StatefulAuthenticator
@@ -127,6 +127,11 @@ class ResourceController(JsonPatchControllerMixin, ModelRestController):
     @Resource.expose
     def get(self, id_: int=None):
         q = DBSession.query(Resource)
+        status = context.query.get('status')
+
+        if status:
+            raise HTTPStatus(status)
+
         if id_ is not None:
             return q.filter(Resource.id == id_).one_or_none()
         return q

--- a/src/client.js
+++ b/src/client.js
@@ -5,10 +5,11 @@ import JsonPatchRequest from './jsonpatch'
 import Metadata from './metadata'
 
 export default class Session {
-  constructor (baseUrl, tokenLocalStorageKey = 'token', authenticator) {
+  constructor (baseUrl, tokenLocalStorageKey = 'token', authenticator, errorHandlers = {}) {
     this.baseUrl = baseUrl
     this.tokenLocalStorageKey = tokenLocalStorageKey
     this._authenticator = authenticator
+    this.errorHandlers = errorHandlers
   }
 
   // FIXME: We have to remove this method because Authenticator is a abstract class and can't be
@@ -26,7 +27,8 @@ export default class Session {
   }
 
   request (...args) {
-    return new Request(this, ...args).addAuthenticationHeaders(false)
+    return new Request(this, ...args).setErrorHandlers(this.errorHandlers)
+      .addAuthenticationHeaders(false)
   }
 
   requestModel (ModelClass, url, verb) {

--- a/src/http.js
+++ b/src/http.js
@@ -7,7 +7,8 @@ export default function doHttpRequest (url, options, responseFactory) {
     headers: {},
     encoding: 'json',
     postProcessor: null,
-    xhrWithCredentials: true
+    xhrWithCredentials: true,
+    errorHandlers: {}
   }
   Object.assign(defaultOptions, options)
 
@@ -23,6 +24,9 @@ export default function doHttpRequest (url, options, responseFactory) {
         } else {
           resolve(response)
         }
+      } else if (defaultOptions.errorHandlers[response.status]) {
+        defaultOptions.errorHandlers[response.status](response.status, window.location.pathname.substr(1))
+        reject(response)
       } else {
         reject(response)
       }

--- a/src/request.js
+++ b/src/request.js
@@ -15,6 +15,7 @@ export default class Request {
     queryString = [],
     encoding = 'json',
     withCredentials = true,
+    errorHandlers = {},
     ModelClass = null
   ) {
     this.resource = resource
@@ -26,6 +27,7 @@ export default class Request {
     this.encoding = encoding
     this.postProcessor = null
     this.xhrWithCredentials = withCredentials
+    this.errorHandlers = errorHandlers
     this.ModelClass = ModelClass
   }
 
@@ -46,6 +48,11 @@ export default class Request {
 
   setModelClass (ModelClass) {
     this.ModelClass = ModelClass
+    return this
+  }
+
+  setErrorHandlers (errorHandlers) {
+    this.errorHandlers = errorHandlers
     return this
   }
 
@@ -165,7 +172,8 @@ export default class Request {
       headers: this.headers,
       encoding: this.encoding,
       postProcessor: this.postProcessor,
-      xhrWithCredentials: this.xhrWithCredentials
+      xhrWithCredentials: this.xhrWithCredentials,
+      errorHandlers: this.errorHandlers
     }, (...args) => { return this.responseFactory(...args) })
   }
 }

--- a/tests/errorhandling.test.js
+++ b/tests/errorhandling.test.js
@@ -14,7 +14,6 @@ describe('Error handling', function () {
       expect(resp.status).toEqual(401)
       let newLocation = new URL(fakeWindow.location.href)
       expect(newLocation.pathname).toEqual('/login')
-      debugger
     })
     done()
   })

--- a/tests/errorhandling.test.js
+++ b/tests/errorhandling.test.js
@@ -1,0 +1,21 @@
+/**
+ * Created by mehdi on 10/01/2018.
+ */
+
+import { MockupClient, fakeWindow } from './helpers'
+
+describe('Error handling', function () {
+  it('401', function (done) {
+    let c = new MockupClient()
+    let request = c.request('resources')
+      .addQueryString('status', '401 unauthorized')
+    expect(fakeWindow.location.href).toEqual(window.location.href)
+    request.send().catch(resp => {
+      expect(resp.status).toEqual(401)
+      let newLocation = new URL(fakeWindow.location.href)
+      expect(newLocation.pathname).toEqual('/login')
+      debugger
+    })
+    done()
+  })
+})

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -24,9 +24,23 @@ class MyAuthenticator extends Authenticator {
 
 let authenticator = new MyAuthenticator()
 
+// We can not change actual window.location.href in a test runner. so we fake it!
+let fakeWindow = {
+  location: new URL(window.location.href)
+}
+const errorHandler = {
+  401: (status, redirectUrl) => {
+    if (status === 401) {
+      fakeWindow.location.href = `${window.location.origin}/login?redirect=${window.__karma__.config.serverUrl}/${redirectUrl}`
+    }
+  }
+}
+
 export class MockupClient extends Client {
   constructor () {
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000
-    super(window.__karma__.config.serverUrl, 'token', authenticator)
+    super(window.__karma__.config.serverUrl, 'token', authenticator, errorHandler)
   }
 }
+
+export { fakeWindow }


### PR DESCRIPTION
please consider these 3 things:

  1. test runner doesn't allow to change the `window.location.href` inside a test. so I tested this feature using a `fakeWindow` object to simulate this process.
  2. All tests are currently passed but after updating the nanohttp I got an error on `GET /echo` in the console that says: `content-length is required`. Do I have to change anything in front-end codes? or this is a back-end issue?
  3. After talking with @mrastiak, we decided to pass pathName instead of full URL to the callback function (that issued in #57). do you agree or you want to change to full URL?